### PR TITLE
Updated change password failure feedback

### DIFF
--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -48,6 +48,7 @@ const addEventHandlers = function () {
   $('#sign-in').on('submit', onSignIn)
   $('#sign-out').on('click', onSignOut)
   $('#change-pw').on('submit', onChangePassword)
+  $('#change-password-modal').on('hidden.bs.modal', () => $('#change-password-feedback').empty())
 }
 
 module.exports = {

--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -47,9 +47,8 @@ const signOutFailed = function () {
 
 // shows toast for error handling
 const changePasswordFailed = function () {
-  const header = 'Error!'
-  const msg = 'Failed to change password, make sure they both match'
-  showToast(msg, header)
+  const msg = 'Failed to change password, please enter your current password in old password field'
+  $('#change-password-feedback').text(msg)
 }
 
 // inform user of successful password change

--- a/index.html
+++ b/index.html
@@ -145,8 +145,7 @@
             <span aria-hidden="true">&times;</span>
           </button>
         </div>
-
-        <div>
+        <div class="modal-body">
           <form class="input-group m-3 " id="change-pw">
             <fieldset>
               <input class="credentials" name="passwords[old]" type="text" placeholder="old password" required>
@@ -154,6 +153,9 @@
               <input type="submit" class="btn btn-outline-secondary btn-sm mr-4" value="Submit">
             </fieldset>
           </form>
+        </div>
+        <div class="modal-footer">
+          <p id="change-password-feedback" class="text-danger text-align-left"></p>
         </div>
       </div>
     </div>

--- a/lib/show-toast.js
+++ b/lib/show-toast.js
@@ -1,4 +1,4 @@
-// shows an  toast with a custom msg and header, default header is "error"
+// shows a toast with a custom msg and header, default header is "error"
 const showToast = function (msg, header) {
   $('.toast-header').text(header)
   $('.toast').toast('show')


### PR DESCRIPTION
- Updated change password feedback to show at the modal footer instead of as a toast.
- Added code to clear feedback msg on modal close.
- Updated change password modal to include modal-body and modal-footer
- Corrected grammar in showToast lib function